### PR TITLE
Fix binary operator associativity

### DIFF
--- a/fusion-compiler/src/ast/mod.rs
+++ b/fusion-compiler/src/ast/mod.rs
@@ -404,6 +404,12 @@ pub enum ASTBinaryOperatorKind {
     GreaterThanOrEqual,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum ASTBinaryOperatorAssociativity {
+    Left,
+    Right,
+}
+
 #[derive(Debug, Clone)]
 pub struct ASTBinaryOperator {
     pub kind: ASTBinaryOperatorKind,
@@ -431,6 +437,13 @@ impl ASTBinaryOperator {
             ASTBinaryOperatorKind::LessThanOrEqual => 29,
             ASTBinaryOperatorKind::GreaterThan => 29,
             ASTBinaryOperatorKind::GreaterThanOrEqual => 29,
+        }
+    }
+
+    pub fn associativity(&self) -> ASTBinaryOperatorAssociativity {
+        match self.kind {
+            ASTBinaryOperatorKind::Power => ASTBinaryOperatorAssociativity::Right,
+            _ => ASTBinaryOperatorAssociativity::Left,
         }
     }
 }


### PR DESCRIPTION
Hi!

Stumbled across your videos and used them for inspiration in my own compiler construction project. Very helpful!

However, there's a bug in the parser as it is written. All binary operators are considered right-associative. However, subtraction and division are left-associative. The simplest example demonstrating the problem is `1 - 1 + 1`. This should obviously evaluate to `1`, as it should parse into `(1 - 1) + 1`. However, the parser as written parses it into `1 - (1 + 1)`, giving the result `-1` when evaluated!

This PR implements the algorithm from [this wikipedia article on operator-precedence parsing](https://en.wikipedia.org/wiki/Operator-precedence_parser#Pseudocode) as a fix.

I'm opening the PR to the `main` branch, as I had trouble getting the `dev` branch to compile properly to run tests making sure I didn't break anything. Feel free to just put the code on `dev` instead and close this PR. :)