### PR TITLE
Part 8: Make functions values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fusion-Lang
 
-### Today
+### Stream #7
 
 - [x] Implement Fix for binary operator associativity (as explained in this [PR](https://github.com/julian-hartl/fusion-lang/pull/1) by [@martinkauppinen](https://github.com/martinkauppinen)) 
 - [x] Remove AST Prefix from ast components
@@ -13,6 +13,28 @@
     - Function declaration
     - Statement
 - [x] Make everything an expression
-- Gather function symbols during parsing (we have all the information we need) instead of in a separate pass
+
+### Today
+- [] Make functions expressions
+  ```
+    let add = func (a: int, b: int) -> int {
+      return a + b
+    }
+    let sum = add(1, 2)
+    let test = func (anotherFunc: (int, int) -> int) -> int {
+      return anotherFunc(1, 2)
+    }
+    sum
+  ```
+
+
+### Todo
 - Add tests for evaluator
+- Add rec keyword that references the immediately enclosing function
+  ```
+  sum = add(sum, func () -> {
+  // This function is not named, so we can't reference it by name
+  rec()
+  })
+  ```
 

--- a/fusion-compiler/src/ast/evaluator.rs
+++ b/fusion-compiler/src/ast/evaluator.rs
@@ -1,32 +1,35 @@
 use std::collections::HashMap;
 use std::env::var;
 use std::fmt::format;
+use fusion_compiler::Idx;
 
-use crate::ast::{Ast, AssignExpr, BinaryExpr, BinOpKind, BlockExpr, BoolExpr, CallExpr, Expr, FunctionDeclaration, IfExpr, LetStmt, NumberExpr, ParenthesizedExpr, UnaryExpr, UnOpKid, VarExpr, WhileStmt, Stmt};
+use crate::ast::{AssignExpr, Ast, BinaryExpr, BinOpKind, BlockExpr, BoolExpr, CallExpr, Expr, ExprId, FuncExpr, FunctionDeclaration, IfExpr, LetStmt, NumberExpr, ParenthesizedExpr, RecExpr, Stmt, UnaryExpr, UnOpKid, VarExpr, WhileStmt};
 use crate::ast::visitor::ASTVisitor;
-use crate::compilation_unit::{GlobalScope, VariableIdx};
+use crate::compilation_unit::{FunctionIdx, GlobalScope, VariableIdx};
 use crate::text::span::TextSpan;
-
+use crate::typings::Type;
+#[derive(Debug)]
 pub struct Frame {
-    variables: HashMap<VariableIdx, i64>,
+    variables: HashMap<VariableIdx, Value>,
 }
 
 impl Frame {
     fn new() -> Self {
         Self {
-            variables: HashMap::new()
+            variables: HashMap::new(),
         }
     }
 
-    fn insert(&mut self, idx: VariableIdx, value: i64) {
+    fn insert(&mut self, idx: VariableIdx, value: Value) {
         self.variables.insert(idx, value);
     }
 
-    fn get(&self, idx: &VariableIdx) -> Option<&i64> {
+    fn get(&self, idx: &VariableIdx) -> Option<&Value> {
         self.variables.get(idx)
     }
 }
 
+#[derive(Debug)]
 pub struct Frames {
     frames: Vec<Frame>,
 }
@@ -46,20 +49,20 @@ impl Frames {
         self.frames.pop();
     }
 
-    fn update(&mut self, idx: VariableIdx, value: i64) {
+    fn update(&mut self, idx: VariableIdx, value: Value) {
         for frame in self.frames.iter_mut().rev() {
-            if frame.variables.contains_key(&idx) {
+            if frame.get(&idx).is_some() {
                 frame.insert(idx, value);
                 return;
             }
         }
     }
 
-    fn insert(&mut self, idx: VariableIdx, value: i64) {
+    fn insert(&mut self, idx: VariableIdx, value: Value) {
         self.frames.last_mut().unwrap().insert(idx, value);
     }
 
-    fn get(&self, idx: &VariableIdx) -> Option<&i64> {
+    fn get(&self, idx: &VariableIdx) -> Option<&Value> {
         for frame in self.frames.iter().rev() {
             if let Some(value) = frame.get(idx) {
                 return Some(value);
@@ -69,8 +72,39 @@ impl Frames {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Value {
+    Number(i64),
+    Boolean(bool),
+    Function(FunctionIdx),
+}
+
+impl Value {
+    pub fn expect_boolean(&self) -> bool {
+        match self {
+            Value::Boolean(value) => *value,
+            _ => panic!("Expected boolean value")
+        }
+    }
+
+    pub fn expect_number(&self) -> i64 {
+        match self {
+            Value::Number(value) => *value,
+            _ => panic!("Expected number value")
+        }
+    }
+
+    pub fn expect_function(&self) -> FunctionIdx {
+        match self {
+            Value::Function(value) => *value,
+            _ => panic!("Expected function value")
+        }
+    }
+}
+
+
 pub struct ASTEvaluator<'a> {
-    pub last_value: Option<i64>,
+    pub last_value: Option<Value>,
     pub frames: Frames,
     pub global_scope: &'a GlobalScope,
 }
@@ -82,15 +116,6 @@ impl<'a> ASTEvaluator<'a> {
         Self { last_value: None, frames: Frames::new(), global_scope }
     }
 
-    fn eval_boolean_instruction<F>(&self, instruction: F) -> i64 where F: FnOnce() -> bool {
-        let result = instruction();
-        if result {
-            1
-        } else {
-            0
-        }
-    }
-
     fn push_frame(&mut self) {
         self.frames.push();
     }
@@ -98,16 +123,19 @@ impl<'a> ASTEvaluator<'a> {
     fn pop_frame(&mut self) {
         self.frames.pop();
     }
+
+    fn expect_last_value(&self) -> Value {
+        *self.last_value.as_ref().expect("Expected last value to be set")
+    }
 }
 
 impl<'a> ASTVisitor for ASTEvaluator<'a> {
+    fn visit_func_expr(&mut self, ast: &mut Ast, func_expr: &FuncExpr, expr_id: ExprId) {}
 
-    fn visit_function_declaration(&mut self, ast: &mut Ast, func_decl_statement: &FunctionDeclaration) {}
-
-    fn visit_while_statement(&mut self, ast: &mut Ast,while_statement: &WhileStmt) {
+    fn visit_while_statement(&mut self, ast: &mut Ast, while_statement: &WhileStmt) {
         self.push_frame();
         self.visit_expression(ast, while_statement.condition);
-        while self.last_value.unwrap() != 0 {
+        while self.expect_last_value().expect_boolean() {
             self.visit_expression(ast, while_statement.body);
             self.visit_expression(ast, while_statement.condition);
         }
@@ -125,7 +153,7 @@ impl<'a> ASTVisitor for ASTEvaluator<'a> {
     fn visit_if_expression(&mut self, ast: &mut Ast, if_statement: &IfExpr, expr: &Expr) {
         self.push_frame();
         self.visit_expression(ast, if_statement.condition);
-        if self.last_value.unwrap() != 0 {
+        if self.expect_last_value().expect_boolean() {
             self.push_frame();
             self.visit_expression(ast, if_statement.then_branch);
             self.pop_frame();
@@ -139,13 +167,26 @@ impl<'a> ASTVisitor for ASTEvaluator<'a> {
         self.pop_frame();
     }
 
-    fn visit_let_statement(&mut self,ast: &mut Ast,let_statement: &LetStmt, stmt: &Stmt) {
+    fn visit_let_statement(&mut self, ast: &mut Ast, let_statement: &LetStmt, stmt: &Stmt) {
         self.visit_expression(ast, let_statement.initializer);
-        self.frames.insert(let_statement.variable_idx, self.last_value.unwrap());
+        self.frames.insert(let_statement.variable_idx, self.expect_last_value());
     }
 
-    fn visit_call_expression(&mut self, ast: &mut Ast,call_expression: &CallExpr, expr: &Expr) {
-        let function_idx = self.global_scope.lookup_function(&call_expression.identifier.span.literal).unwrap();
+    fn visit_rec_expression(&mut self, ast: &mut Ast, expr: &RecExpr, expr_id: ExprId) {
+        let expr = ast.query_expr(expr_id);
+        let function = match expr.ty {
+            Type::Function(function) => function,
+            _ => panic!("Expected function type")
+        };
+        self.last_value = Some(Value::Function(function));
+    }
+
+    fn visit_call_expression(&mut self, ast: &mut Ast, call_expression: &CallExpr, expr: &Expr) {
+        let callee = ast.query_expr(call_expression.callee);
+        let function_idx = match &callee.ty {
+            Type::Function(function_idx) => *function_idx,
+            _ => panic!("Expected function type")
+        };
         let function = self.global_scope.functions.get(function_idx);
         let mut arguments = Vec::new();
         for argument in &call_expression.arguments {
@@ -157,66 +198,66 @@ impl<'a> ASTVisitor for ASTEvaluator<'a> {
             self.frames.insert(*param, *argument);
         }
 
-        self.visit_statement(ast, function.body);
+        self.visit_expression(ast, function.body);
         self.pop_frame();
     }
 
-    fn visit_assignment_expression(&mut self,ast: &mut Ast, assign_expr: &AssignExpr, expr: &Expr) {
+    fn visit_assignment_expression(&mut self, ast: &mut Ast, assign_expr: &AssignExpr, expr: &Expr) {
         self.visit_expression(ast, assign_expr.expression);
         self.frames.update(assign_expr.variable_idx, self.last_value.unwrap());
     }
 
-    fn visit_variable_expression(&mut self, ast: &mut Ast,var_expr: &VarExpr, expr: &Expr) {
+    fn visit_variable_expression(&mut self, ast: &mut Ast, var_expr: &VarExpr, expr: &Expr) {
         let identifier = &var_expr.identifier.span.literal;
-        self.last_value = Some(*self.frames.get(&var_expr.variable_idx).expect(format!("Variable {} not found", identifier).as_str()));
+        self.last_value = Some(*self.frames.get(&var_expr.variable_idx).expect(format!("Variable {} '{}' not found", var_expr.variable_idx.as_index(),  identifier).as_str()));
     }
 
-    fn visit_number_expression(&mut self,ast: &mut Ast, number: &NumberExpr, expr: &Expr) {
-        self.last_value = Some(number.number);
+    fn visit_number_expression(&mut self, ast: &mut Ast, number: &NumberExpr, expr: &Expr) {
+        self.last_value = Some(Value::Number(number.number));
     }
 
 
-    fn visit_boolean_expression(&mut self,ast: &mut Ast, boolean: &BoolExpr, expr: &Expr) {
-        self.last_value = Some(boolean.value as i64);
+    fn visit_boolean_expression(&mut self, ast: &mut Ast, boolean: &BoolExpr, expr: &Expr) {
+        self.last_value = Some(Value::Boolean(boolean.value));
     }
 
-    fn visit_error(&mut self, ast: &mut Ast,span: &TextSpan) {
+    fn visit_error(&mut self, ast: &mut Ast, span: &TextSpan) {
         todo!()
     }
 
-    fn visit_unary_expression(&mut self,ast: &mut Ast, unary_expression: &UnaryExpr, expr: &Expr) {
+    fn visit_unary_expression(&mut self, ast: &mut Ast, unary_expression: &UnaryExpr, expr: &Expr) {
         self.visit_expression(ast, unary_expression.operand);
-        let operand = self.last_value.unwrap();
-        self.last_value = Some(match unary_expression.operator.kind {
+        let operand = self.expect_last_value().expect_number();
+        self.last_value = Some(Value::Number(match unary_expression.operator.kind {
             UnOpKid::Minus => -operand,
             UnOpKid::BitwiseNot => !operand,
-        });
+        }));
     }
 
-    fn visit_binary_expression(&mut self,ast: &mut Ast, binary_expr: &BinaryExpr, expr: &Expr) {
+    fn visit_binary_expression(&mut self, ast: &mut Ast, binary_expr: &BinaryExpr, expr: &Expr) {
         self.visit_expression(ast, binary_expr.left);
-        let left = self.last_value.unwrap();
+        let left = self.expect_last_value();
         self.visit_expression(ast, binary_expr.right);
-        let right = self.last_value.unwrap();
+        let right = self.expect_last_value();
         self.last_value = Some(match binary_expr.operator.kind {
-            BinOpKind::Plus => left + right,
-            BinOpKind::Minus => left - right,
-            BinOpKind::Multiply => left * right,
-            BinOpKind::Divide => left / right,
-            BinOpKind::Power => left.pow(right as u32),
-            BinOpKind::BitwiseAnd => left & right,
-            BinOpKind::BitwiseOr => left | right,
-            BinOpKind::BitwiseXor => left ^ right,
-            BinOpKind::Equals => if left == right { 1 } else { 0 },
-            BinOpKind::NotEquals => self.eval_boolean_instruction(|| left != right),
-            BinOpKind::LessThan => self.eval_boolean_instruction(|| left < right),
-            BinOpKind::LessThanOrEqual => self.eval_boolean_instruction(|| left <= right),
-            BinOpKind::GreaterThan => self.eval_boolean_instruction(|| left > right),
-            BinOpKind::GreaterThanOrEqual => self.eval_boolean_instruction(|| left >= right),
+            BinOpKind::Plus => Value::Number(left.expect_number() + right.expect_number()),
+            BinOpKind::Minus => Value::Number(left.expect_number() - right.expect_number()),
+            BinOpKind::Multiply => Value::Number(left.expect_number() * right.expect_number()),
+            BinOpKind::Divide => Value::Number(left.expect_number() / right.expect_number()),
+            BinOpKind::Power => Value::Number(left.expect_number().pow(right.expect_number() as u32)),
+            BinOpKind::BitwiseAnd => Value::Number(left.expect_number() & right.expect_number()),
+            BinOpKind::BitwiseOr => Value::Number(left.expect_number() | right.expect_number()),
+            BinOpKind::BitwiseXor => Value::Number(left.expect_number() ^ right.expect_number()),
+            BinOpKind::Equals => Value::Boolean(left == right),
+            BinOpKind::NotEquals => Value::Boolean(left != right),
+            BinOpKind::LessThan => Value::Boolean(left.expect_number() < right.expect_number()),
+            BinOpKind::LessThanOrEqual => Value::Boolean(left.expect_number() <= right.expect_number()),
+            BinOpKind::GreaterThan => Value::Boolean(left.expect_number() > right.expect_number()),
+            BinOpKind::GreaterThanOrEqual => Value::Boolean(left.expect_number() >= right.expect_number()),
         });
     }
 
-    fn visit_parenthesized_expression(&mut self,ast: &mut Ast, parenthesized_expression: &ParenthesizedExpr, expr: &Expr) {
+    fn visit_parenthesized_expression(&mut self, ast: &mut Ast, parenthesized_expression: &ParenthesizedExpr, expr: &Expr) {
         self.visit_expression(ast, parenthesized_expression.expression);
     }
 }

--- a/fusion-compiler/src/ast/lexer.rs
+++ b/fusion-compiler/src/ast/lexer.rs
@@ -31,6 +31,7 @@ pub enum TokenKind {
     While,
     Func,
     Return,
+    Rec,
     // Separators
     LeftParen,
     RightParen,
@@ -87,6 +88,7 @@ impl Display for TokenKind {
             TokenKind::Colon => write!(f, "Colon"),
             TokenKind::Arrow => write!(f, "Arrow"),
             TokenKind::SemiColon => write!(f, "SemiColon"),
+            TokenKind::Rec => write!(f, "Rec"),
         }
     }
 }
@@ -143,6 +145,7 @@ impl<'a> Lexer<'a> {
                     "while" => TokenKind::While,
                     "func" => TokenKind::Func,
                     "return" => TokenKind::Return,
+                    "rec" => TokenKind::Rec,
                     _ => TokenKind::Identifier,
                 }
 

--- a/fusion-compiler/src/ast/visitor.rs
+++ b/fusion-compiler/src/ast/visitor.rs
@@ -1,21 +1,17 @@
 use termion::color::{Fg, Reset};
 
-use crate::ast::{AssignExpr, Ast, BinaryExpr, BlockExpr, BoolExpr, CallExpr, Expr, ExprId, ExprKind, FunctionDeclaration, IfExpr, ItemId, ItemKind, LetStmt, NumberExpr, ParenthesizedExpr, ReturnStmt, Stmt, StmtId, StmtKind, UnaryExpr, VarExpr, WhileStmt};
+use crate::ast::{AssignExpr, Ast, BinaryExpr, BlockExpr, BoolExpr, CallExpr, Expr, ExprId, ExprKind, FuncExpr, FunctionDeclaration, IfExpr, ItemId, ItemKind, LetStmt, NumberExpr, ParenthesizedExpr, RecExpr, ReturnStmt, Stmt, StmtId, StmtKind, UnaryExpr, VarExpr, WhileStmt};
 use crate::ast::printer::ASTPrinter;
 use crate::text::span::TextSpan;
 
 pub trait ASTVisitor {
-
     fn visit_item(&mut self, ast: &mut Ast, item: ItemId) {
-       self.visit_item_default(ast, item);
+        self.visit_item_default(ast, item);
     }
 
     fn visit_item_default(&mut self, ast: &mut Ast, item: ItemId) {
         let item = ast.query_item(item).clone();
         match &item.kind {
-            ItemKind::Func(func_decl) => {
-                self.visit_function_declaration(ast, func_decl);
-            }
             ItemKind::Stmt(stmt) => {
                 self.visit_statement(ast, *stmt);
             }
@@ -40,7 +36,7 @@ pub trait ASTVisitor {
         }
     }
 
-    fn visit_function_declaration(&mut self, ast: &mut Ast, func_decl: &FunctionDeclaration);
+    fn visit_func_expr(&mut self, ast: &mut Ast, func_expr: &FuncExpr, expr_id: ExprId);
 
     fn visit_return_statement(&mut self, ast: &mut Ast, return_statement: &ReturnStmt) {
         if let Some(expr) = &return_statement.return_value {
@@ -100,19 +96,28 @@ pub trait ASTVisitor {
                 self.visit_call_expression(ast, expr, &expression);
             }
             ExprKind::If(expr) => {
-                    self.visit_if_expression(ast, expr, &expression);
+                self.visit_if_expression(ast, expr, &expression);
             }
             ExprKind::Block(block_expr) => {
                 self.visit_block_expr(ast, &block_expr, &expression);
             }
+            ExprKind::Func(func_expr) => {
+                self.visit_func_expr(ast, func_expr, expression.id);
+            }
+            ExprKind::Rec(expr) => {
+                self.visit_rec_expression(ast, expr, expression.id);
+            }
         }
     }
+
+    fn visit_rec_expression(&mut self, ast: &mut Ast, expr: &RecExpr, expr_id: ExprId) ;
+
     fn visit_call_expression(&mut self, ast: &mut Ast, call_expression: &CallExpr, expr: &Expr) {
         for argument in &call_expression.arguments {
             self.visit_expression(ast, *argument);
         }
     }
-    fn visit_expression(&mut self, ast: &mut Ast, expression:ExprId) {
+    fn visit_expression(&mut self, ast: &mut Ast, expression: ExprId) {
         self.do_visit_expression(ast, expression);
     }
 

--- a/fusion-compiler/src/diagnostics/mod.rs
+++ b/fusion-compiler/src/diagnostics/mod.rs
@@ -60,12 +60,12 @@ impl DiagnosticsBag {
         self.report_error(format!("Undeclared variable '{}'", token.span.literal), token.span.clone());
     }
 
-    pub fn report_undeclared_function(&mut self, token: &Token) {
-        self.report_error(format!("Undeclared function '{}'", token.span.literal), token.span.clone());
+    pub fn report_cannot_call_no_callable_expression(&mut self, callee_span: &TextSpan, callee_type: &Type) {
+        self.report_error(format!("Cannot call non-callable expression of type '{}'", callee_type), callee_span.clone());
     }
 
-    pub fn report_invalid_argument_count(&mut self, token: &Token, expected: usize, actual: usize) {
-        self.report_error(format!("Function '{}' expects {} arguments, but was given {}", token.span.literal, expected, actual), token.span.clone());
+    pub fn report_invalid_argument_count(&mut self, callee_span: &TextSpan, expected: usize, actual: usize) {
+        self.report_error(format!("Function '{}' expects {} arguments, but was given {}", callee_span.literal, expected, actual), callee_span.clone());
     }
 
     pub fn report_function_already_declared(&mut self, token: &Token) {
@@ -82,6 +82,10 @@ impl DiagnosticsBag {
 
     pub fn report_cannot_return_outside_function(&mut self, token: &Token) {
         self.report_error(format!("Cannot use 'return' outside of function"), token.span.clone());
+    }
+
+    pub fn report_cannot_use_rec_outside_of_function(&mut self, token: &Token) {
+        self.report_error(format!("Cannot use 'rec' outside of function"), token.span.clone());
     }
 }
 

--- a/fusion-compiler/src/main.rs
+++ b/fusion-compiler/src/main.rs
@@ -11,11 +11,26 @@ fn main() -> Result<(), ()> {
         1 - 1 + 1
         let a = 10
         let b = 20
-        func add(a: int, b: int) -> int {
-            return a + b
+        let b = b + 20
+        let mul = func (a: int, b: int) -> int {
+            let add = func (a: int, b: int) -> int {
+                let hadd = func(a: int, runs: int) -> int {
+                    if runs == 0 {
+                        return a
+                    }
+                    return rec(a + 1, runs - 1)
+                }
+                return hadd(a, b)
+            }
+            let sum = 0
+            while b > 0 {
+                sum = add(sum, b)
+                b = b - 1
+            }
+            return sum
         }
 
-        let c = add(a, b)
+        let c = mul(a, b)
 
         let d = if a == b {
             {

--- a/fusion-compiler/src/typings/mod.rs
+++ b/fusion-compiler/src/typings/mod.rs
@@ -1,10 +1,12 @@
 use std::fmt::{Display, Formatter};
+use crate::compilation_unit::FunctionIdx;
 
 #[derive(Debug, Clone)]
 pub enum Type {
     Int,
     Bool,
     Void,
+    Function(FunctionIdx),
     Unresolved,
     Error,
 }
@@ -16,6 +18,7 @@ impl Display for Type {
             Type::Bool => "bool",
             Type::Unresolved => "unresolved",
             Type::Void => "void",
+            Type::Function(_) => "function",
             Type::Error => "?",
         };
 


### PR DESCRIPTION
In this episode we have converted functions to not be items anymore, but expressions. This means that we must now assign functions to variables to name them. This comes with quite some trickery, such as recursion and have actually ran into an issue with rust's HashMap which we will try to fix next time.