### PR TITLE
Part 9: Refactorings & Transpiling to C

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
     - Statement
 - [x] Make everything an expression
 
-### Today
-- [] Make functions expressions
+### Stream #8
+- [x] Make functions expressions
   ```
     let add = func (a: int, b: int) -> int {
       return a + b
@@ -28,13 +28,20 @@
   ```
 
 
-### Todo
-- Add tests for evaluator
-- Add rec keyword that references the immediately enclosing function
-  ```
-  sum = add(sum, func () -> {
-  // This function is not named, so we can't reference it by name
-  rec()
-  })
-  ```
+### Stream #9
+- Rethink language design
+  - I'd like it not to become too functional - Therefore we should reconsider the current way of function declarations
+Instead of
+```
+let add = func(a: int, b: int) -> int {
+  return a + b
+}
+```
+We could do
+```
+func add(a: int, b: int) -> int {
+  return a + b
+}
+```
+- Refactor symbol resolving => Move to parsing stage because we have all the information (except for types) at that point
 

--- a/fusion-compiler/src/ast/lexer.rs
+++ b/fusion-compiler/src/ast/lexer.rs
@@ -31,7 +31,6 @@ pub enum TokenKind {
     While,
     Func,
     Return,
-    Rec,
     // Separators
     LeftParen,
     RightParen,
@@ -88,7 +87,6 @@ impl Display for TokenKind {
             TokenKind::Colon => write!(f, "Colon"),
             TokenKind::Arrow => write!(f, "Arrow"),
             TokenKind::SemiColon => write!(f, "SemiColon"),
-            TokenKind::Rec => write!(f, "Rec"),
         }
     }
 }
@@ -145,7 +143,6 @@ impl<'a> Lexer<'a> {
                     "while" => TokenKind::While,
                     "func" => TokenKind::Func,
                     "return" => TokenKind::Return,
-                    "rec" => TokenKind::Rec,
                     _ => TokenKind::Identifier,
                 }
 

--- a/fusion-compiler/src/ast/printer.rs
+++ b/fusion-compiler/src/ast/printer.rs
@@ -76,17 +76,18 @@ impl ASTPrinter {
 }
 
 impl ASTVisitor for ASTPrinter {
-    fn visit_func_expr(&mut self, ast: &mut Ast, func_expr: &FuncExpr, expr_id: ExprId) {
+    fn visit_func_decl(&mut self, ast: &mut Ast, func_decl: &FunctionDeclaration, item_id: ItemId) {
         self.add_keyword("func");
         self.add_whitespace();
-        let decl = &func_expr.decl;
-        let are_parameters_empty = decl.parameters.is_empty();
+        self.add_text(&func_decl.identifier.span.literal);
+        self.add_whitespace();
+        let are_parameters_empty = func_decl.parameters.is_empty();
         if !are_parameters_empty {
             self.add_text("(");
         } else {
             self.add_whitespace();
         }
-        for (i, parameter) in decl.parameters.iter().enumerate() {
+        for (i, parameter) in func_decl.parameters.iter().enumerate() {
             if i != 0 {
                 self.add_text(",");
                 self.add_whitespace();
@@ -98,7 +99,7 @@ impl ASTVisitor for ASTPrinter {
             self.add_text(")");
             self.add_whitespace();
         }
-        self.visit_expression(ast, decl.body);
+        self.visit_expression(ast, func_decl.body);
     }
     fn visit_return_statement(&mut self, ast: &mut Ast, return_statement: &ReturnStmt) {
         self.add_keyword("return");
@@ -163,12 +164,8 @@ impl ASTVisitor for ASTPrinter {
         ));
     }
 
-    fn visit_rec_expression(&mut self, ast: &mut Ast, expr: &RecExpr, expr_id: ExprId) {
-        self.add_keyword("rec");
-    }
-
     fn visit_call_expression(&mut self, ast: &mut Ast, call_expression: &CallExpr, expr: &Expr) {
-        self.visit_expression(ast, call_expression.callee);
+        self.add_text(&call_expression.callee.span.literal);
         self.add_text("(");
         for (i, argument) in call_expression.arguments.iter().enumerate() {
             if i != 0 {

--- a/fusion-compiler/src/ast/visitor.rs
+++ b/fusion-compiler/src/ast/visitor.rs
@@ -1,6 +1,6 @@
 use termion::color::{Fg, Reset};
 
-use crate::ast::{AssignExpr, Ast, BinaryExpr, BlockExpr, BoolExpr, CallExpr, Expr, ExprId, ExprKind, FuncExpr, FunctionDeclaration, IfExpr, ItemId, ItemKind, LetStmt, NumberExpr, ParenthesizedExpr, RecExpr, ReturnStmt, Stmt, StmtId, StmtKind, UnaryExpr, VarExpr, WhileStmt};
+use crate::ast::{AssignExpr, Ast, BinaryExpr, BlockExpr, BoolExpr, CallExpr, Expr, ExprId, ExprKind, FunctionDeclaration, IfExpr, ItemId, ItemKind, LetStmt, NumberExpr, ParenthesizedExpr, ReturnStmt, Stmt, StmtId, StmtKind, UnaryExpr, VarExpr, WhileStmt};
 use crate::ast::printer::ASTPrinter;
 use crate::text::span::TextSpan;
 
@@ -15,8 +15,13 @@ pub trait ASTVisitor {
             ItemKind::Stmt(stmt) => {
                 self.visit_statement(ast, *stmt);
             }
+            ItemKind::Function(func_decl) => {
+                self.visit_func_decl(ast, func_decl, item.id);
+            }
         }
     }
+
+    fn visit_func_decl(&mut self, ast: &mut Ast, func_decl: &FunctionDeclaration, item_id: ItemId);
 
     fn do_visit_statement(&mut self, ast: &mut Ast, statement: StmtId) {
         let statement = ast.query_stmt(statement).clone();
@@ -35,8 +40,6 @@ pub trait ASTVisitor {
             }
         }
     }
-
-    fn visit_func_expr(&mut self, ast: &mut Ast, func_expr: &FuncExpr, expr_id: ExprId);
 
     fn visit_return_statement(&mut self, ast: &mut Ast, return_statement: &ReturnStmt) {
         if let Some(expr) = &return_statement.return_value {
@@ -101,16 +104,8 @@ pub trait ASTVisitor {
             ExprKind::Block(block_expr) => {
                 self.visit_block_expr(ast, &block_expr, &expression);
             }
-            ExprKind::Func(func_expr) => {
-                self.visit_func_expr(ast, func_expr, expression.id);
-            }
-            ExprKind::Rec(expr) => {
-                self.visit_rec_expression(ast, expr, expression.id);
-            }
         }
     }
-
-    fn visit_rec_expression(&mut self, ast: &mut Ast, expr: &RecExpr, expr_id: ExprId) ;
 
     fn visit_call_expression(&mut self, ast: &mut Ast, call_expression: &CallExpr, expr: &Expr) {
         for argument in &call_expression.arguments {

--- a/fusion-compiler/src/codegen/mod.rs
+++ b/fusion-compiler/src/codegen/mod.rs
@@ -1,0 +1,231 @@
+use crate::ast::{AssignExpr, Ast, BinaryExpr, BinOperator, BinOpKind, BlockExpr, BoolExpr, Expr, ExprId, ExprKind, FunctionDeclaration, ItemId, ItemKind, LetStmt, NumberExpr, ParenthesizedExpr, Stmt, StmtId, UnaryExpr, UnOperator, UnOpKind, VarExpr};
+use crate::ast::visitor::ASTVisitor;
+use crate::compilation_unit::{GlobalScope, VariableIdx};
+use crate::text::span::TextSpan;
+use crate::typings::Type;
+
+pub struct CTranspiler<'a> {
+    pub result: String,
+    pub indent: usize,
+    pub global_scope: &'a GlobalScope,
+    pub l_value_stack: Vec<(VariableIdx, ExprId)>,
+}
+
+impl <'a> CTranspiler<'a> {
+    pub fn new(global_scope: &'a GlobalScope) -> Self {
+        Self {
+            result: String::new(),
+            indent: 0,
+            global_scope,
+            l_value_stack: Vec::new(),
+        }
+    }
+
+    pub fn transpile(mut self, ast: &mut Ast) -> String {
+        let items = ast.items.clone();
+
+        for item in items.iter() {
+            match &item.kind {
+                ItemKind::Stmt(stmt) => {
+                }
+                ItemKind::Function(function_decl) => {
+                    self.visit_func_decl(ast, function_decl, item.id);
+                }
+            }
+        }
+        self.result.push_str("int main() {\n");
+        self.indent += 1;
+        for item in items.iter() {
+            match &item.kind {
+                ItemKind::Stmt(stmt) => {
+                    self.visit_statement(ast, *stmt);
+                }
+                ItemKind::Function(_) => {}
+            }
+        }
+        self.write_ident();
+        self.result.push_str("return 0;\n");
+        self.result.push_str("}\n");
+        return self.result;
+    }
+
+    fn transpile_type(ty: &Type) -> String {
+        return match ty {
+            Type::Int => "int".to_string(),
+            Type::Bool => "int".to_string(),
+            Type::Void => "void".to_string(),
+            Type::Unresolved => panic!("Unresolved type"),
+            Type::Error => panic!("Error type"),
+        };
+    }
+
+    fn transpile_unary_operator(&self, operator: &UnOperator) -> &'static str {
+        return match &operator.kind {
+            UnOpKind::Minus => "-",
+            UnOpKind::BitwiseNot => "~",
+        };
+    }
+
+    fn transpile_binary_operator(&self, operator: &BinOperator) -> &'static str {
+        return match &operator.kind {
+            BinOpKind::Plus => "+",
+            BinOpKind::Minus => "-",
+            BinOpKind::Multiply => "*",
+            BinOpKind::Divide => "/",
+            BinOpKind::Equals => "==",
+            BinOpKind::NotEquals => "!=",
+            BinOpKind::LessThan => "<",
+            BinOpKind::GreaterThan => ">",
+            BinOpKind::BitwiseAnd => "&",
+            BinOpKind::BitwiseOr => "|",
+            BinOpKind::BitwiseXor => "^",
+            BinOpKind::Power => panic!("Power operator not supported"),
+            BinOpKind::LessThanOrEqual => "<=",
+            BinOpKind::GreaterThanOrEqual => ">=",
+        };
+    }
+
+    fn is_valid_r_value(&self,ast: &Ast, expr: ExprId) -> bool {
+        let expr = ast.query_expr(expr);
+        return match &expr.kind {
+            ExprKind::Number(_) => true,
+            ExprKind::Binary(binary_expr) => {
+                let left = self.is_valid_r_value(ast,binary_expr.left);
+                let right = self.is_valid_r_value(ast, binary_expr.right);
+                left && right
+            }
+            ExprKind::Unary(_) => self.is_valid_r_value(ast, expr.id),
+            ExprKind::Parenthesized(parenthesized_expr) => self.is_valid_r_value(ast, parenthesized_expr.expression),
+            ExprKind::Variable(_) => true,
+            ExprKind::Assignment(assign_expr) => self.is_valid_r_value(ast, assign_expr.expression),
+            ExprKind::Boolean(_) => true,
+            ExprKind::Call(call_expr) => {
+                for argument in call_expr.arguments.iter() {
+                    if !self.is_valid_r_value(ast, *argument) {
+                        return false;
+                    }
+                }
+                true
+            }
+            ExprKind::If(_) => false,
+            ExprKind::Block(_) => false,
+            ExprKind::Error(_) => panic!("Error expression"),
+        };
+    }
+
+    fn write_newline(&mut self) {
+        self.result.push('\n');
+    }
+
+    fn write_ident(&mut self) {
+        for _ in 0..self.indent {
+            self.result.push_str("  ");
+        }
+    }
+
+    fn write_type(&mut self, ty: &Type) {
+        self.result.push_str(&CTranspiler::transpile_type(ty));
+    }
+
+    fn write_whitespace(&mut self) {
+        self.result.push_str(" ");
+    }
+}
+
+impl ASTVisitor for CTranspiler<'_> {
+    fn visit_func_decl(&mut self, ast: &mut Ast, func_decl: &FunctionDeclaration, item_id: ItemId) {
+        let function = self.global_scope.functions.get(func_decl.idx);
+        self.write_type(&function.return_type);
+        self.write_whitespace();
+        self.result.push_str(&function.name);
+        self.result.push_str("(");
+        for (i, parameter) in function.parameters.iter().enumerate() {
+            let parameter = self.global_scope.variables.get(*parameter);
+            self.write_type(&parameter.ty);
+            self.write_whitespace();
+            self.result.push_str(&parameter.name);
+            if i != function.parameters.len() - 1 {
+                self.result.push_str(", ");
+            }
+        }
+        self.result.push_str(") {\n");
+        self.indent += 1;
+        self.visit_expression(ast, func_decl.body);
+        self.indent -= 1;
+        self.result.push_str("}\n");
+    }
+
+    fn visit_statement(&mut self, ast: &mut Ast, statement: StmtId) {
+        self.write_ident();
+        self.do_visit_statement(ast, statement);
+        self.result.push(';');
+        self.write_newline();
+    }
+
+    fn visit_let_statement(&mut self, ast: &mut Ast, let_statement: &LetStmt, stmt: &Stmt) {
+        let variable = self.global_scope.variables.get(let_statement.variable_idx);
+        self.write_type(&variable.ty);
+        self.write_whitespace();
+        self.result.push_str(&variable.name);
+        self.result.push_str(" = ");
+        self.visit_expression(ast, let_statement.initializer);
+    }
+
+    fn visit_variable_expression(&mut self, ast: &mut Ast, variable_expression: &VarExpr, expr: &Expr) {
+        let variable = self.global_scope.variables.get(variable_expression.variable_idx);
+        self.result.push_str(&variable.name);
+    }
+
+    fn visit_number_expression(&mut self, ast: &mut Ast, number: &NumberExpr, expr: &Expr) {
+        self.result.push_str(&number.number.to_string());
+    }
+
+    fn visit_boolean_expression(&mut self, ast: &mut Ast, boolean: &BoolExpr, expr: &Expr) {
+        self.result.push_str(if boolean.value { "1" } else { "0" });
+    }
+
+    fn visit_error(&mut self, ast: &mut Ast, span: &TextSpan) {
+        self.result.push_str("/* error */");
+    }
+
+    fn visit_unary_expression(&mut self, ast: &mut Ast, unary_expression: &UnaryExpr, expr: &Expr) {
+        self.result.push_str(self.transpile_unary_operator(&unary_expression.operator));
+        self.visit_expression(ast, unary_expression.operand);
+    }
+
+    fn visit_assignment_expression(&mut self, ast: &mut Ast, assignment_expression: &AssignExpr, expr: &Expr) {
+        self.result.push_str(&self.global_scope.variables.get(assignment_expression.variable_idx).name);
+        self.result.push_str(" = ");
+        self.visit_expression(ast, assignment_expression.expression);
+    }
+
+    fn visit_binary_expression(&mut self, ast: &mut Ast, binary_expression: &BinaryExpr, expr: &Expr) {
+        self.visit_expression(ast, binary_expression.left);
+        self.write_whitespace();
+        self.result.push_str(self.transpile_binary_operator(&binary_expression.operator));
+        self.write_whitespace();
+        self.visit_expression(ast, binary_expression.right);
+    }
+
+    fn visit_parenthesized_expression(&mut self, ast: &mut Ast, parenthesized_expression: &ParenthesizedExpr, expr: &Expr) {
+        self.result.push('(');
+        self.visit_expression(ast, parenthesized_expression.expression);
+        self.result.push(')');
+    }
+
+    fn visit_block_expr(&mut self, ast: &mut Ast, block_expr: &BlockExpr, expr: &Expr) {
+        for statement in block_expr.stmts.iter().take(block_expr.stmts.len() - 1) {
+            self.visit_statement(ast, *statement);
+        }
+        if let Some((assign_to, r_value_id)) = self.l_value_stack.last() {
+            if *r_value_id == expr.id {
+                self.result.push_str(&self.global_scope.variables.get(*assign_to).name);
+                self.result.push_str(" = ");
+            }
+        }
+        if let Some(last_stmt) = block_expr.stmts.last() {
+            self.visit_statement(ast, *last_stmt);
+        }
+
+    }
+}

--- a/fusion-compiler/src/diagnostics/mod.rs
+++ b/fusion-compiler/src/diagnostics/mod.rs
@@ -60,12 +60,16 @@ impl DiagnosticsBag {
         self.report_error(format!("Undeclared variable '{}'", token.span.literal), token.span.clone());
     }
 
+    pub fn report_undeclared_function(&mut self, token: &Token) {
+        self.report_error(format!("Undeclared function '{}'", token.span.literal), token.span.clone());
+    }
+
     pub fn report_cannot_call_no_callable_expression(&mut self, callee_span: &TextSpan, callee_type: &Type) {
         self.report_error(format!("Cannot call non-callable expression of type '{}'", callee_type), callee_span.clone());
     }
 
     pub fn report_invalid_argument_count(&mut self, callee_span: &TextSpan, expected: usize, actual: usize) {
-        self.report_error(format!("Function '{}' expects {} arguments, but was given {}", callee_span.literal, expected, actual), callee_span.clone());
+        self.report_error(format!("Function '{}' expects {} {}, but was given {}", callee_span.literal, expected, if expected == 1 { "argument" } else { "arguments" }, actual), callee_span.clone());
     }
 
     pub fn report_function_already_declared(&mut self, token: &Token) {

--- a/fusion-compiler/src/main.rs
+++ b/fusion-compiler/src/main.rs
@@ -1,10 +1,16 @@
-use crate::compilation_unit::CompilationUnit;
+#![allow(clippy::needless_return)]
 
+use std::fs::File;
+use std::io::Write;
+use std::process::Command;
+use crate::codegen::CTranspiler;
+use crate::compilation_unit::CompilationUnit;
 mod ast;
 mod diagnostics;
 mod text;
 mod compilation_unit;
 mod typings;
+mod codegen;
 
 fn main() -> Result<(), ()> {
     let input = "\
@@ -12,19 +18,12 @@ fn main() -> Result<(), ()> {
         let a = 10
         let b = 20
         let b = b + 20
-        let mul = func (a: int, b: int) -> int {
-            let add = func (a: int, b: int) -> int {
-                let hadd = func(a: int, runs: int) -> int {
-                    if runs == 0 {
-                        return a
-                    }
-                    return rec(a + 1, runs - 1)
-                }
-                return hadd(a, b)
-            }
+
+        let z = mul(a, a)
+        func mul (a: int, b: int) -> int {
             let sum = 0
             while b > 0 {
-                sum = add(sum, b)
+                sum = sum + a
                 b = b - 1
             }
             return sum
@@ -44,9 +43,26 @@ fn main() -> Result<(), ()> {
             20
         }
         let e = c + d
-        e
+        z
     ";
     let mut compilation_unit = CompilationUnit::compile(input).map_err(|_| ())?;
     compilation_unit.run();
+    let mut c_transpiler = CTranspiler::new(&compilation_unit.global_scope);
+    let transpiled_code = c_transpiler.transpile(&mut compilation_unit.ast);
+    println!("{}", transpiled_code);
+    let mut c_file = File::create("out.c").unwrap();
+    c_file.write_all(transpiled_code.as_bytes()).unwrap();
+    // compile with clang using rust
+    Command::new("clang")
+        .arg("out.c")
+        .arg("-o")
+        .arg("out")
+        .status()
+        .unwrap();
+    // run the compiled binary
+    Command::new("./out")
+        .status()
+        .unwrap();
+
     Ok(())
 }

--- a/fusion-compiler/src/typings/mod.rs
+++ b/fusion-compiler/src/typings/mod.rs
@@ -6,7 +6,6 @@ pub enum Type {
     Int,
     Bool,
     Void,
-    Function(FunctionIdx),
     Unresolved,
     Error,
 }
@@ -18,7 +17,6 @@ impl Display for Type {
             Type::Bool => "bool",
             Type::Unresolved => "unresolved",
             Type::Void => "void",
-            Type::Function(_) => "function",
             Type::Error => "?",
         };
 


### PR DESCRIPTION
This pull request includes the following changes:

- Moving resolving of static symbols (such as global variables or functions) to the parsing pass. This improves performance as no second pass just for static symbol resolving is required
- Reverting changes of #3, where functions where made expressions. I decided to do this to make further features easier to implement as dealing with lambdas and such at this point in development is just too much
- Initial implementation of transpilation to the C programming language